### PR TITLE
http_get: Enhance http command

### DIFF
--- a/http_get/cmd.go
+++ b/http_get/cmd.go
@@ -2,55 +2,88 @@ package http_get
 
 import (
 	"fmt"
-	"log"
-	"os"
-
 	"github.com/foundriesio/fioconfig/sotatoml"
 	"github.com/foundriesio/fioconfig/transport"
 	"github.com/spf13/cobra"
+	"log"
+	"net/url"
+	"os"
 )
 
-var (
-	url      string
-	logLevel int
+type (
+	httpOptions struct {
+		// TODO: make it global flag, it should be defined as a global flag in the root command
+		configPaths []string
+	}
 )
 
 func NewCommand() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "http-get",
-		Short: "Perform an HTTP GET request using Foundries.io credentials",
-		Run:   doDockerGet,
+	httpCmd := &cobra.Command{
+		Use:   "http <get> <endpoint or full URL> [flags]",
+		Short: "Perform an HTTP request to a server by using mTLS credentials",
+		Long: `Perform an HTTP request to a server by using mTLS credentials.
+The command supports HTTP requests to a specified endpoint or full URL.
+By default, it uses the server base URL defined in the configuration file.`,
+		Args: cobra.MinimumNArgs(1),
 	}
 
-	cmd.Flags().StringVarP(&url, "url", "u", "", "url to get, mandatory")
-	cmd.Flags().IntVar(&logLevel, "loglevel", 2, "set log level 0-5 (trace, debug, info, warning, error, fatal)")
+	opts := httpOptions{}
 
-	// viper.BindEnv("config", "SOTA_DIR")
-	// viper.BindPFlag("src-dir", cmd.Flags().Lookup("src-dir"))
-	// viper.BindPFlag("config", cmd.Flags().Lookup("config"))
+	getCmd := &cobra.Command{
+		Use:  "get <endpoint or URL>",
+		Args: cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			doGet(cmd, args, &opts)
+		},
+	}
 
-	return cmd
+	// TODO: Add support for other HTTP methods like POST, PUT, PATCH, DELETE
+	for _, cmd := range []*cobra.Command{getCmd} {
+		// TODO: make it global flag, it should be defined as a global flag in the root command
+		cmd.Flags().StringSliceVarP(&opts.configPaths, "config-paths", "c",
+			sotatoml.DEF_CONFIG_ORDER, "A comma-separated list of paths to search for .toml configuration files")
+		httpCmd.AddCommand(cmd)
+	}
+
+	return httpCmd
 }
 
-func doDockerGet(cmd *cobra.Command, args []string) {
-	if url == "" {
-		cmd.Help()
-		return
-	}
-
-	configPaths := sotatoml.DEF_CONFIG_ORDER
-	config, err := sotatoml.NewAppConfig(configPaths)
+func doGet(cmd *cobra.Command, args []string, opts *httpOptions) {
+	config, err := sotatoml.NewAppConfig(opts.configPaths)
 	if err != nil {
-		log.Println("ERROR - unable to decode sota.toml:", err)
+		log.Println("ERROR - unable to parse the configuration files: ", err)
 		os.Exit(1)
 	}
+
+	url, err := getUrl(config, args[0])
 
 	client := transport.CreateClient(config)
-	resp, err := transport.HttpGet(client, url, map[string]string{})
+	resp, err := transport.HttpGet(client, url, nil)
 	if err != nil || resp.StatusCode != 200 {
-		log.Printf("Error fetching URL %s: %v\n", url, err)
+		if err == nil {
+			log.Printf("Error:  %s: %s\n", url, resp)
+		} else {
+			log.Printf("Error:  %s: %v\n", url, err)
+		}
 		os.Exit(1)
 	}
+	fmt.Print(resp)
+}
 
-	fmt.Print(string(resp.Body))
+func getUrl(cfg *sotatoml.AppConfig, endpointOrUrl string) (string, error) {
+	url, err := url.Parse(endpointOrUrl)
+	if err != nil {
+		return "", fmt.Errorf("invalid URL or endpoint: %w", err)
+	}
+	if url.Scheme == "https" {
+		return url.String(), nil
+	}
+
+	server := cfg.Get("tls.server")
+	url, err = url.Parse(server)
+	if err != nil {
+		return "", fmt.Errorf("invalid server base URL in config: %w", err)
+	}
+	url.Path += endpointOrUrl
+	return url.String(), nil
 }


### PR DESCRIPTION
1. Rename the command to `http` so we can add support of other http verbs in the future in addition to `http get`.

2. Add ability to specify just a name of the endpoint to make request to. A base URL is obtained from the .toml configuration in this case.

3. Add ability to specify paths to configuration directorie(s). If not specified the default config dirs are assumed/applied.